### PR TITLE
Fix/issue 2

### DIFF
--- a/cmd/jetapi/helpers.go
+++ b/cmd/jetapi/helpers.go
@@ -79,6 +79,9 @@ func (app *application) parseAPIQueries(
 		return nil, fmt.Errorf("%d", http.StatusBadRequest)
 	}
 
+	onlyJP := queryParams.Get("only_jp") == "true"
+	onlyFR := queryParams.Get("only_fr") == "true"
+
 	photos, err := handleNumQuery(queryParams, "photos")
 	if err != nil {
 		return nil, err
@@ -95,7 +98,13 @@ func (app *application) parseAPIQueries(
 		flights = 20
 	}
 
-	q := &sites.APIQueries{Reg: reg, Photos: photos, Flights: flights}
+	q := &sites.APIQueries{
+		Reg:     reg,
+		Photos:  photos,
+		Flights: flights,
+		OnlyJP:  onlyJP,
+		OnlyFR:  onlyFR,
+	}
 	return q, nil
 }
 

--- a/cmd/jetapi/helpers.go
+++ b/cmd/jetapi/helpers.go
@@ -14,9 +14,13 @@ import (
 	"github.com/macsencasaus/jetapi/internal/sites"
 )
 
-func (app *application) serverError(w http.ResponseWriter, err error) {
+func (app *application) logErr(err error) {
 	trace := fmt.Sprintf("%v\n%s", err, debug.Stack())
 	app.errorLog.Println(trace)
+}
+
+func (app *application) serverError(w http.ResponseWriter, err error) {
+	app.logErr(err)
 	status := http.StatusInternalServerError
 	http.Error(w, http.StatusText(status), status)
 }

--- a/cmd/jetapi/routes.go
+++ b/cmd/jetapi/routes.go
@@ -48,17 +48,38 @@ func (app *application) api(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sr, err := sites.Scrape(q)
-	if sr == nil {
-		app.serverError(w, err)
-		return
+	var jsonResult []byte
+
+	if q.OnlyJP == q.OnlyFR {
+		sr, err := sites.Scrape(q)
+		if sr == nil {
+			app.serverError(w, err)
+			return
+		}
+
+		if err != nil {
+			app.logErr(fmt.Errorf("Partial Error: %v", err))
+		}
+
+		jsonResult, err = json.Marshal(sr)
+	} else if q.OnlyJP {
+		jpRes, err := sites.ScrapeJetPhotos(q)
+		if err != nil {
+			app.serverError(w, err)
+			return
+		}
+
+		jsonResult, err = json.Marshal(jpRes)
+	} else if q.OnlyFR {
+		frRes, err := sites.ScrapeFlightRadar(q)
+		if err != nil {
+			app.serverError(w, err)
+			return
+		}
+
+		jsonResult, err = json.Marshal(frRes)
 	}
 
-	if err != nil {
-		app.logErr(fmt.Errorf("Partial Error: %v", err))
-	}
-
-	jsonResult, err := json.Marshal(sr)
 	if err != nil {
 		app.serverError(w, fmt.Errorf("Error encoding json: %v", err))
 		return

--- a/cmd/jetapi/routes.go
+++ b/cmd/jetapi/routes.go
@@ -49,9 +49,13 @@ func (app *application) api(w http.ResponseWriter, r *http.Request) {
 	}
 
 	sr, err := sites.Scrape(q)
-	if err != nil {
+	if sr == nil {
 		app.serverError(w, err)
 		return
+	}
+
+	if err != nil {
+		app.logErr(fmt.Errorf("Partial Error: %v", err))
 	}
 
 	jsonResult, err := json.Marshal(sr)
@@ -72,12 +76,12 @@ func (app *application) aircraftSearch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	q = &sites.APIQueries{Reg: q.Reg, Photos: 3, Flights: 8}
-	ji, err := sites.Scrape(q)
-	if err != nil {
+	sr, err := sites.Scrape(q)
+	if sr == nil {
 		app.notFoundPage(w)
 		return
 	}
-	app.render(w, http.StatusOK, page, ji)
+	app.render(w, http.StatusOK, page, sr)
 }
 
 func (app *application) documentation(w http.ResponseWriter, r *http.Request) {

--- a/internal/sites/flightradar.go
+++ b/internal/sites/flightradar.go
@@ -51,19 +51,27 @@ func scrapeFlightRadar(q *APIQueries) (*FlightRadarResult, error) {
 	aircraft := strings.TrimSpace(aircraftArr[0])
 
 	// airline
+	// can either be a link, typically for commerical airlines,
+	// or text, for private owners
 	err = s.Advance("span", "details", 1)
 	if err != nil {
 		return nil, frError("advancing to airline text", reg, URL, err)
 	}
-	airlineArr, err := s.ScrapeText("a", "", 1)
-	if err != nil {
-		return nil, frError("scraping airline text", reg, URL, err)
+	airline, ok := s.TryScrapeText()
+	if !ok {
+		airlineArr, err := s.ScrapeText("a", "", 1)
+		if err != nil {
+			return nil, frError("scraping airline text", reg, URL, err)
+		}
+		airline = strings.TrimSpace(airlineArr[0])
+	} else {
+		airline = strings.TrimSpace(airline)
 	}
-	airline := strings.TrimSpace(airlineArr[0])
 
 	// details
 	res, err := s.ScrapeText("span", "details", 5)
-	if err != nil {
+	if err != nil || len(res) != 5 {
+		fmt.Printf("details: %v\n", res)
 		return nil, frError("scraping details", reg, URL, err)
 	}
 	operator := strings.TrimSpace(res[0])

--- a/internal/sites/flightradar.go
+++ b/internal/sites/flightradar.go
@@ -32,7 +32,7 @@ type FlightAttributes struct {
 
 const frAircraftURL = "https://www.flightradar24.com/data/aircraft/"
 
-func scrapeFlightRadar(q *APIQueries) (*FlightRadarResult, error) {
+func ScrapeFlightRadar(q *APIQueries) (*FlightRadarResult, error) {
 	reg := q.Reg
 	URL := fmt.Sprintf("%s%s", frAircraftURL, reg)
 	b, err := scraper.FetchHTML(URL)

--- a/internal/sites/jetphotos.go
+++ b/internal/sites/jetphotos.go
@@ -29,7 +29,7 @@ type ImageAttributes struct {
 
 const jpHomeURL = "https://www.jetphotos.com"
 
-func scrapeJetPhotos(q *APIQueries) (*JetPhotosResult, error) {
+func ScrapeJetPhotos(q *APIQueries) (*JetPhotosResult, error) {
 	reg := q.Reg
 	if q.Photos == 0 {
 		return &JetPhotosResult{Reg: strings.ToUpper(reg)}, nil

--- a/internal/sites/sites.go
+++ b/internal/sites/sites.go
@@ -15,6 +15,8 @@ type APIQueries struct {
 	Reg     string
 	Photos  int
 	Flights int
+	OnlyJP  bool
+	OnlyFR  bool
 }
 
 func Scrape(q *APIQueries) (*ScrapeResult, error) {
@@ -26,7 +28,7 @@ func Scrape(q *APIQueries) (*ScrapeResult, error) {
 	g, _ := errgroup.WithContext(context.Background())
 
 	g.Go(func() error {
-		res, err := scrapeJetPhotos(q)
+		res, err := ScrapeJetPhotos(q)
 		if err != nil {
 			return fmt.Errorf("JetPhotos Error: %v", err)
 		}
@@ -35,7 +37,7 @@ func Scrape(q *APIQueries) (*ScrapeResult, error) {
 	})
 
 	g.Go(func() error {
-		res, err := scrapeFlightRadar(q)
+		res, err := ScrapeFlightRadar(q)
 		if err != nil {
 			return fmt.Errorf("FlightRadar Error: %v", err)
 		}

--- a/internal/sites/sites.go
+++ b/internal/sites/sites.go
@@ -43,9 +43,11 @@ func Scrape(q *APIQueries) (*ScrapeResult, error) {
 		return nil
 	})
 
-	if err := g.Wait(); err != nil {
+	err := g.Wait()
+
+	if err != nil && jpResult == nil && frResult == nil {
 		return nil, err
 	}
 
-	return &ScrapeResult{JetPhotos: jpResult, FlightRadar: frResult}, nil
+	return &ScrapeResult{JetPhotos: jpResult, FlightRadar: frResult}, err
 }

--- a/ui/html/pages/documentation.tmpl.html
+++ b/ui/html/pages/documentation.tmpl.html
@@ -51,6 +51,28 @@
             Max: 20
         </th>
     </tr>
+    <tr>
+        <th>only_jp</th>
+        <th>Optional</th>
+        <th>
+            Whether to only scrape JetPhotos
+            <br />
+            Default: false
+            <br />
+            true/false
+        </th>
+    </tr>
+    <tr>
+        <th>only_fr</th>
+        <th>Optional</th>
+        <th>
+            Whether to only scrape FlightRadar24
+            <br />
+            Default: false
+            <br />
+            true/false
+        </th>
+    </tr>
 </table>
 <p class="message">
     See the <a href="/querybuilder">Query Builder</a> to interactively create a

--- a/ui/html/pages/querybuilder.tmpl.html
+++ b/ui/html/pages/querybuilder.tmpl.html
@@ -44,6 +44,16 @@
             />
         </div>
     </div>
+    <div class="qb_options">
+        <div>
+            <input type="checkbox" id="only_jp" />
+            <label>Only JP</label>
+        </div>
+        <div>
+            <input type="checkbox" id="only_fr" />
+            <label>Only FR</label>
+        </div>
+    </div>
     <button type="submit" class="get" id="get">Get JSON</button>
     <div id="json"></div>
 </div>

--- a/ui/static/css/main.css
+++ b/ui/static/css/main.css
@@ -238,6 +238,7 @@ button.download {
     width: 50%;
     display: flex;
     justify-content: space-around;
+    margin-top: 10px;
 }
 
 .qb_options input {

--- a/ui/static/js/querybuilder.js
+++ b/ui/static/js/querybuilder.js
@@ -61,6 +61,7 @@ const getButton = document.getElementById("get");
 const jsonDiv = document.getElementById("json");
 
 getButton.addEventListener("click", function (_) {
+    reg = regField.value;
     jsonDiv.innerHTML = "<p>Loading...</p>";
     fetch(queryUrl.textContent)
         .then((response) => {
@@ -74,7 +75,6 @@ getButton.addEventListener("click", function (_) {
         })
         .then((data) => {
             const jsonString = JSON.stringify(data, null, 2);
-            const reg = data.JetPhotos.Reg;
             jsonDiv.innerHTML = ` 
                 <div class="json_output">
                     <pre id="raw_json">${jsonString}</pre>

--- a/ui/static/js/querybuilder.js
+++ b/ui/static/js/querybuilder.js
@@ -4,6 +4,8 @@ regField.value = "";
 const queryUrl = document.getElementById("query_url");
 const photosInput = document.getElementById("photos_input");
 const flightsInput = document.getElementById("flights_input");
+const onlyJPInput = document.getElementById("only_jp");
+const onlyFRInput = document.getElementById("only_fr");
 
 const apiUrl = `${window.location.origin}/api?reg=`;
 
@@ -33,6 +35,13 @@ document.getElementById("main").addEventListener("input", function (_) {
     if (flights != 20) {
         query += "&flights=" + flights;
     }
+    if (onlyJPInput.checked) {
+        query += "&only_jp=true";
+    }
+    if (onlyFRInput.checked) {
+        query += "&only_fr=true";
+    }
+
     if (regField.value != "") {
         queryUrl.textContent = query;
     } else {


### PR DESCRIPTION
fixes #2 

- Improved scraping support for privately owned aircraft on FlightRadar24
- If one site fails, returns null for that site but still includes data from the other
- Added only_jp and only_fr query parameters to limit scraping to a specific site